### PR TITLE
Adding base module

### DIFF
--- a/src/envo/Makefile
+++ b/src/envo/Makefile
@@ -26,12 +26,14 @@ full_test: test envo.check-obo subsets/EnvO-Lite-GSC.check-obo
 test_python:
 	python3 --version
 
-build: all_modules all_imports envo.owl envo.obo envo.json subsets/envo-basic.obo subsets/envo-basic.json subsets/EnvO-Lite-GSC.obo 
+build: base all_modules all_imports envo.owl envo.obo envo.json subsets/envo-basic.obo subsets/envo-basic.json subsets/EnvO-Lite-GSC.obo 
 
 prepare_release: build  copy-release
 
 copy-release:
-	cp -pr catalog-v001.xml envo.obo envo.owl envo.json subsets mappings imports ../..
+	cp -pr catalog-v001.xml envo.obo envo.owl envo.json envo-base.owl subsets mappings imports ../..
+
+base: envo-base.owl
 
 # generic conversion for OGs
 %.json: %.owl
@@ -41,6 +43,11 @@ debug.owl: envo-edit.owl
 	owltools --use-catalog  $< --merge-support-ontologies --run-reasoner -r elk -u -m $@
 
 #release: envo-basic.obo release-diffs
+
+envo-base.owl: envo-edit.owl
+	owltools $(USECAT) $< --remove-imports-declarations -o $@.tmp
+	owltools $(USECAT) $@.tmp  $(ALL_MODS_OWL) --merge-support-ontologies -o $@
+
 
 # Merge in all module files, whilst removing the corresponding import
 envo-edit-module-merge.owl: envo-edit.owl


### PR DESCRIPTION
See https://github.com/INCATools/ontology-development-kit/issues/50

@pbuttigieg - note that this has 2 commits, one adds the base module to the release folder (top level). This was built from the current envo-edit and doesn't correspond to the last release. I think it's OK to merge but if you want you can cherry pick the Makefile changes, just make sure to git add next release