### PR TITLE
addition of id ranges for new design patterns

### DIFF
--- a/src/envo/envo-idranges.owl
+++ b/src/envo/envo-idranges.owl
@@ -15,140 +15,140 @@ Prefix: owl: <http://www.w3.org/2002/07/owl#>
 Ontology: <http://purl.obolibrary.org/obo/envo/envo-idranges.owl>
 
 
-Annotations: 
+Annotations:
     idsfor: "ENVO",
     idprefix: "http://purl.obolibrary.org/obo/ENVO_",
     iddigits: 8
 
 AnnotationProperty: idprefix:
 
-    
+
 AnnotationProperty: iddigits:
 
-    
+
 AnnotationProperty: idsfor:
 
-    
+
 AnnotationProperty: allocatedto:
 
 
 Datatype: idrange:1
 
-    Annotations: 
+    Annotations:
         allocatedto: "Norman Morrison"
-    
-    EquivalentTo: 
+
+    EquivalentTo:
         xsd:integer[> 1 , <= 999999]
-        
+
 Datatype: idrange:2
 
-    Annotations: 
+    Annotations:
         allocatedto: "Pier Luigi Buttigieg"
-    
-    EquivalentTo: 
+
+    EquivalentTo:
         xsd:integer[> 1000000 , <= 1999999]
-        
+
 Datatype: idrange:3
 
-    Annotations: 
+    Annotations:
         allocatedto: "Chris Mungall"
-    
-    EquivalentTo: 
+
+    EquivalentTo:
         xsd:integer[> 2000000 , <= 2999999]
 
-    
+
 
 Datatype: idrange:4
 
-    Annotations: 
+    Annotations:
         allocatedto: "TermGenie"
-    
-    EquivalentTo: 
+
+    EquivalentTo:
         xsd:integer[> 8000000 , <= 8999999]
 
 Datatype: idrange:5
 
-    Annotations: 
+    Annotations:
         allocatedto: "ENVO-P, E-A-L"
-    
-    EquivalentTo: 
+
+    EquivalentTo:
         xsd:integer[> 9000000 , <= 9099999]
 
 Datatype: idrange:6
 
-    Annotations: 
+    Annotations:
         allocatedto: "ENVO-P, E-Q-L"
-    
-    EquivalentTo: 
+
+    EquivalentTo:
         xsd:integer[> 9100000 , <= 9199999]
 
 Datatype: idrange:7
 
-    Annotations: 
+    Annotations:
         allocatedto: "ENVO-P, E-A"
-    
-    EquivalentTo: 
+
+    EquivalentTo:
         xsd:integer[> 9200000 , <= 9299999]
 
 
 Datatype: idrange:8
 
-    Annotations: 
+    Annotations:
         allocatedto: "Kai Blumberg"
-    
-    EquivalentTo: 
+
+    EquivalentTo:
         xsd:integer[> 3000000 , <= 3100000]
-    
+
 Datatype: idrange:9
 
-    Annotations: 
+    Annotations:
         allocatedto: "ENVO-P, E-Content-E"
-    
-    EquivalentTo: 
+
+    EquivalentTo:
         xsd:integer[> 9300000 , <= 9399999]
-        
-            
+
+
 Datatype: idrange:10
 
-    Annotations: 
+    Annotations:
         allocatedto: "ENVO-P, E-NumberOf-E"
-    
-    EquivalentTo: 
+
+    EquivalentTo:
         xsd:integer[> 9400000 , <= 9499999]
 
 Datatype: idrange:11
 
-    Annotations: 
+    Annotations:
         allocatedto: "Kai Blumberg pattern generated terms"
-    
-    EquivalentTo: 
+
+    EquivalentTo:
 xsd:integer[> 3100001 , <= 3200000]
 
 Datatype: idrange:12
 
-    Annotations: 
+    Annotations:
         allocatedto: "NCEAS Semantics"
-    
-    EquivalentTo: 
+
+    EquivalentTo:
 xsd:integer[> 4000000 , <= 4100000]
 
-
-Datatype: xsd:integer
-Datatype: rdf:PlainLiteral
-    
 Datatype: idrange:13
 
-    Annotations: 
-        allocatedto: "chemical_concentration.yaml yaml design pattern"
-    
-    EquivalentTo: 
+Annotations:
+    allocatedto: "chemical_concentration.yaml yaml design pattern"
+
+EquivalentTo:
 xsd:integer[> 3200001 , <= 3300000]
 
 
 Datatype: idrange:14
 
-    Annotations: 
-        allocatedto: "ebi_biomes.csv robot design pattern"
-    
-    EquivalentTo: 
+Annotations:
+    allocatedto: "ebi_biomes.csv robot design pattern"
+
+EquivalentTo:
 xsd:integer[> 3300001 , <= 3400000]
+
+
+Datatype: xsd:integer
+Datatype: rdf:PlainLiteral


### PR DESCRIPTION
Addressing #733, I propose the following ID range additions for chemical_concentration and ebi_biomes design patterns, assigning them to id ranges 13 and 14 respectively.