### PR TITLE
Refreshed CHEBI import for #770

### DIFF
--- a/src/envo/imports/chebi_import.owl
+++ b/src/envo/imports/chebi_import.owl
@@ -213,6 +213,24 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/CHEBI_143901 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_143901">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_143907"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">manganese dihydroxide</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_143907 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_143907">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25154"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">manganese hydroxide</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/CHEBI_15022 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_15022">
@@ -1606,6 +1624,15 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_25216"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_38251"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">magnesium porphyrin</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_25154 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_25154">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33743"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">manganese molecular entity</rdfs:label>
     </owl:Class>
     
 
@@ -4264,6 +4291,16 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33497"/>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33676"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">chromium group molecular entity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/CHEBI_33743 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_33743">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33497"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33676"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">manganese group molecular entity</rdfs:label>
     </owl:Class>
     
 

--- a/src/envo/imports/chebi_import.owl
+++ b/src/envo/imports/chebi_import.owl
@@ -2673,6 +2673,7 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/CHEBI_28694">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_33366"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/CHEBI_88184"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">copper atom</rdfs:label>
     </owl:Class>
     

--- a/src/envo/imports/chebi_terms.txt
+++ b/src/envo/imports/chebi_terms.txt
@@ -1,3 +1,4 @@
+http://purl.obolibrary.org/obo/CHEBI_143901 # manganese dihydroxide^M
 http://purl.obolibrary.org/obo/CHEBI_140503 # kaolin
 http://purl.obolibrary.org/obo/CHEBI_9171 # skatole
 http://purl.obolibrary.org/obo/CHEBI_58454 # kynurenate 

--- a/src/envo/imports/chebi_terms.txt
+++ b/src/envo/imports/chebi_terms.txt
@@ -1,4 +1,4 @@
-http://purl.obolibrary.org/obo/CHEBI_143901 # manganese dihydroxide^M
+http://purl.obolibrary.org/obo/CHEBI_143901 # manganese dihydroxide
 http://purl.obolibrary.org/obo/CHEBI_140503 # kaolin
 http://purl.obolibrary.org/obo/CHEBI_9171 # skatole
 http://purl.obolibrary.org/obo/CHEBI_58454 # kynurenate 


### PR DESCRIPTION
Attempting to extend the CHEBI import for deep-sea manganese nodule fields.

The import routine didn't pull the class, however, even though it seems to be [available online](http://purl.obolibrary.org/obo/CHEBI_143901).

@cmungall any ideas? 