### PR TITLE
Adding ID-range for @raissameyer

### DIFF
--- a/src/envo/envo-idranges.owl
+++ b/src/envo/envo-idranges.owl
@@ -191,7 +191,7 @@ Datatype: idrange:20
         allocatedto: "Raissa Meyer"
 
     EquivalentTo:
-        xsd:integer[> 3520000 , <= 3529999]
+        xsd:integer[>= 3520000 , <= 3529999]
 
 Datatype: xsd:integer
 Datatype: rdf:PlainLiteral


### PR DESCRIPTION
Dear EnvO editor team, 

I would like to add this ID-range for myself, as cleared by @pbuttigieg. I've also fixed the numbering in the id-ranges file (which was one off).

I also noticed that there was an edit in the envo.owl file (https://github.com/EnvironmentOntology/envo/commit/56be01367a019edf1b0f7b60f98af2b4ef569d2b). @pbuttigieg I thought this was not to be edited directly. Could you please verify?

Best, 
@raissameyer