### PR TITLE
New terms: low, middle, high atmospheric levels

### DIFF
--- a/src/envo/imports/pato_import.owl
+++ b/src/envo/imports/pato_import.owl
@@ -512,6 +512,16 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/PATO_0000150 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000150">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000051"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A morphologic quality inhering in a bearer by virtue of the bearer&apos;s relative size, organization and distribution of its surface elements or the representation or invention of the appearance of its surface; visual and tactile surface characteristics.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">texture</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/PATO_0000161 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000161">
@@ -711,6 +721,31 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/PATO_0000404 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000404">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001794"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A shape quality inhering in a bearer by virtue of the bearer&apos;s being curled or wound (especially in concentric rings or spirals).</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">spiral</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">helical</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">helicoid</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">helicoidal</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">helix-shaped</oboInOwl:hasRelatedSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">coiled</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000405 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000405">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A shape quality inhering in a bearer by virtue of the bearer&apos;s having parallel chains in undulate fashion on the border.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">curled</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/PATO_0000406 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000406">
@@ -764,6 +799,27 @@
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uniform</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">constant</oboInOwl:hasRelatedSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">invariant</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000440 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000440">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000060"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A pattern quality inhering in a bearer by virtue of the bearer&apos;s having a repeatable or predictable placement.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">regular spatial pattern</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000467 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000467">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000070"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A quality inhering in a bearer by virtue of the bearer&apos;s existence.</obo:IAO_0000115>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">present in organism</oboInOwl:hasRelatedSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">present</rdfs:label>
     </owl:Class>
     
 
@@ -990,6 +1046,31 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/PATO_0000634 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000634">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000060"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A spatial pattern inhering in a bearer by virtue of the bearer&apos;s involvement of only one part or side.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unilateral</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000642 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000642">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000141"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A structural quality inhering in a bearer by virtue of the bearer&apos;s being merged with another entity.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fused</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fused to</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">coalesced</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">joined with</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">merged with</oboInOwl:hasRelatedSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fused with</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/PATO_0000689 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000689">
@@ -1009,6 +1090,16 @@
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">interrupted</oboInOwl:hasExactSynonym>
         <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">intermittent</oboInOwl:hasRelatedSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">discontinuous</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0000701 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0000701">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000150"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A texture quality inhering in a bearer by virtue of the bearer&apos;s processing a surface free of roughness or irregularities.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">smooth</rdfs:label>
     </owl:Class>
     
 
@@ -1648,6 +1739,36 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/PATO_0001360 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001360">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A shape quality inhering in a bearer by virtue of the bearer&apos;s having thin filamentous extensions at its edge.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">filamentous</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001367 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001367">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001925"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A surface feature shape quality inhering in a bearer by virtue of the bearer&apos;s having deeply undulating edges forming lobes.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">lobate</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001410 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001410">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A shape quality inhering in a bearer by virtue of the bearer&apos;s being marked by narrow lines or grooves, usually parallel.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">striated</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/PATO_0001411 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001411">
@@ -1738,6 +1859,16 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/PATO_0001435 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001435">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000141"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A structural quality inhering in a bearer by virtue of the bearer&apos;s having connection or association with another entity.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">attachment quality</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/PATO_0001442 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001442">
@@ -1752,10 +1883,8 @@
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001444">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001442"/>
-        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A broken quality inhering in a bearer by virtue of the bearer&apos;s being broken open.</obo:IAO_0000115>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">burst</oboInOwl:hasExactSynonym>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A structural quality inhering in a bearer by virtue of the bearer&apos;s components no longer being in a single contiguous unit.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fragmented</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ruptured</oboInOwl:hasExactSynonym>
         <oboInOwl:hasNarrowSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fractured</oboInOwl:hasNarrowSynonym>
         <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cracked</oboInOwl:hasRelatedSynonym>
         <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hemorrhaged</oboInOwl:hasRelatedSynonym>
@@ -1774,6 +1903,17 @@
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">calcareous</oboInOwl:hasExactSynonym>
         <oboInOwl:hasNarrowSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">calcification</oboInOwl:hasNarrowSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">calcified</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001453 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001453">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001435"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An attachment quality inhering in a bearer by virtue of the bearer&apos;s lacking connection or association with another entity.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">detached</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">detached from</rdfs:label>
     </owl:Class>
     
 
@@ -2145,6 +2285,16 @@
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">protruding</oboInOwl:hasExactSynonym>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">relational protruding quality</oboInOwl:hasExactSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">protruding</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001608 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001608">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000330"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A spatial pattern inhering in a bearer by virtue of the bearer&apos;s being marked by, consisting of, or diversified with patches.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">patchy</rdfs:label>
     </owl:Class>
     
 
@@ -2702,6 +2852,16 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/PATO_0001794 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001794">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A shape quality inhering in a bearer by virtue of the bearer&apos;s being wound in a continuous series of loops.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">coiling</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/PATO_0001799 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001799">
@@ -2809,6 +2969,16 @@
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An acidity which is relatively high.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">high acidity</oboInOwl:hasExactSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">increased acidity</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001846 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001846">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000141"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A structural quality inhering in a bearer by virtue of the bearer&apos;s being entwined and difficult to unravel.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tangled</rdfs:label>
     </owl:Class>
     
 
@@ -2992,12 +3162,33 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/PATO_0001925 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001925">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A surface shape quality inhering in a bearer by virtue of the bearer&apos;s shape of features present on its surface or outer shell.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">surface feature shape</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/PATO_0001933 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001933">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000140"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A positional quality inhering in a bearer by virtue of the bearer&apos;s being positioned on opposite sides on the same plane.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">opposite</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001935 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001935">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000411"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A shape quality inhering in a bearer by virtue of the bearer&apos;s being roundish, a little inclining to be oblong.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">roundish</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">obtuse</rdfs:label>
     </owl:Class>
     
 
@@ -3032,6 +3223,16 @@
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A variability of size which is relatively high.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">high variability of size</oboInOwl:hasExactSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">increased variability of size</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001960 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001960">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A shape quality inhering in a bearer by virtue of the bearer&apos;s parts or projections being interlocked; for example, the fingers of two hands that are clasped.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">interdigitated</rdfs:label>
     </owl:Class>
     
 
@@ -3073,6 +3274,22 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001241"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A quality that inheres in an entire organism or part of an organism.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">organismal quality</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0001997 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0001997">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000467"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002301"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An amount which is relatively low.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">decreased number</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">present in fewer numbers in organism</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">decreased</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">reduced</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">subnumerary</oboInOwl:hasRelatedSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">decreased amount</rdfs:label>
     </owl:Class>
     
 
@@ -3241,12 +3458,33 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/PATO_0002103 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002103">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000141"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A structural quality inhering in a bearer by virtue of the bearer&apos;s penetrating or permeating another substance or area.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">infiltrating</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">infiltrative</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/PATO_0002107 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002107">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000140"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A positional quality inhering in a bearer by virtue of the bearer&apos;s being at the edge or boundary of a related entity.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">peripheral</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002121 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002121">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000330"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A spatial pattern inhering in a bearer by virtue of the bearer&apos;s structureresembling an irregular meshwork with cross-linking struts.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">trabecular</rdfs:label>
     </owl:Class>
     
 
@@ -3308,6 +3546,17 @@
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002143">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001481"/>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sloped downward</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002165 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002165">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">To bent or hang downwards.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sagging</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">drooping</rdfs:label>
     </owl:Class>
     
 
@@ -3380,6 +3629,22 @@
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A shape quality inhering in a bearer by virtue of the bearer&apos;s being small or narrow in circumference or width in proportion to length or height.</obo:IAO_0000115>
         <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">gracile</oboInOwl:hasRelatedSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">slender</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002215 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002215">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A shape quality inhering in a bearer by virtue of the bearer&apos;s having the shape of a scythe or sickle.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">falcate</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">hooked</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">scythe-shaped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sickle-shaped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">unciform</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">uncinate</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">falciform</rdfs:label>
     </owl:Class>
     
 
@@ -3461,6 +3726,18 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/PATO_0002255 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002255">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000150"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Texture quality inhering in a bearer by virtue of the bearer&apos;s being marked with one or more channels.</obo:IAO_0000115>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">channeled</oboInOwl:hasRelatedSynonym>
+        <oboInOwl:hasRelatedSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">creased</oboInOwl:hasRelatedSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">grooved</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/PATO_0002260 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002260">
@@ -3478,6 +3755,15 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A shape that inheres in a 3 dimensional entity.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">3-D shape</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002267 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002267">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">edge shape</rdfs:label>
     </owl:Class>
     
 
@@ -3623,6 +3909,16 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/PATO_0002311 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002311">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Having a fringe or border of hairlike or fingerlike projections.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fimbriated</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/PATO_0002318 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002318">
@@ -3640,6 +3936,16 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002062"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A temporal distribution pattern of process occurrences within a regulation/reference process.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">temporal distribution quality</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002335 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002335">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A shape quality inhering in a bearer by virtue of the bearer&apos;s being dome-shaped.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">tholiform</rdfs:label>
     </owl:Class>
     
 
@@ -3694,6 +4000,17 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/PATO_0002386 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002386">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002008"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A concave 3-D shape that inheres in the bearer by virtue of the bearer&apos;s shape that is wider at one end and narrow in the middle.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anvil shaped</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">anvil</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/PATO_0002416 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002416">
@@ -3710,6 +4027,16 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000140"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Open to view or not covered by another entity.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">exposed</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002433 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002433">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001925"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A surface feature shape marked by large amounts of relief, often with multiple ridges and grooves in close association. Topographically complex.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">sculpted surface</rdfs:label>
     </owl:Class>
     
 
@@ -3731,6 +4058,26 @@
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000140"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A positional quality inhering in a bearer by virtue of the bearer&apos;s position being displaced from a reference point.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">offset</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002440 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002440">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0001925"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A surface feature shape quality inhering in a bearer by virtue of the degree of the bearer&apos;s highly topographical with ridges, pits, rugosity or other surface structures.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ornamentation</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0002441 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002441">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002440"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A surface feature shape in which the bearer&apos;s surface is highly topographical with ridges, pits, rugosity or other surface structures.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ornamented</rdfs:label>
     </owl:Class>
     
 
@@ -3817,6 +4164,16 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/PATO_0002521 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0002521">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A shape quality inhering in a bearer by virtue of the bearer&apos;s similarity to the appearance of a funnel.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">funnel-shaped</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/PATO_0005001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0005001">
@@ -3828,12 +4185,32 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/PATO_0005005 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0005005">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Shape quality inhering in a bearer expanding outward, or having parts expanding outward, from a center point.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">radiating</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/PATO_0005011 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0005011">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000140"/>
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A positional quality inhering in a bearer by virtue of the bearer possessing an uninterrupted or unbroken connection or spatial distribution relative to the position of another entity.</obo:IAO_0000115>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">continuous with</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0010001 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0010001">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000141"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A structural quality inhering in the bearer by virtue of the bearer consisting of multiple structures lacking any physical connection to each other.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">disconnected</rdfs:label>
     </owl:Class>
     
 
@@ -3889,6 +4266,28 @@
         <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">An increase in combustibility.</obo:IAO_0000115>
         <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">combustible</oboInOwl:hasExactSynonym>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">increased combustibility</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0015030 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0015030">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0000052"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A shape that ineres in a bearer by virtue of the bearer&apos;s mass being distributed in a feather-like fashion.</obo:IAO_0000115>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">feather-shaped</oboInOwl:hasExactSynonym>
+        <oboInOwl:hasExactSynonym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">plumed</oboInOwl:hasExactSynonym>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">plume-shaped</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/PATO_0040008 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/PATO_0040008">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/PATO_0002267"/>
+        <obo:IAO_0000115 rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A shape quality inhering in a bearer by virtue of the bearer&apos;s having an ornamental border consisting of short straight or twisted threads or strips hanging from cut or raveled edges or from a separate band.</obo:IAO_0000115>
+        <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">fringed</rdfs:label>
     </owl:Class>
     
 

--- a/src/envo/imports/pato_terms.txt
+++ b/src/envo/imports/pato_terms.txt
@@ -261,5 +261,6 @@ http://purl.obolibrary.org/obo/PATO_0000406 # curved
 http://purl.obolibrary.org/obo/PATO_0000440 # regular spatial pattern
 http://purl.obolibrary.org/obo/PATO_0001410 # striated
 http://purl.obolibrary.org/obo/PATO_0001453 # detached from
+http://purl.obolibrary.org/obo/PATO_0001935 # obtuse
 http://purl.obolibrary.org/obo/pato#decreased_in_magnitude_relative_to
 http://purl.obolibrary.org/obo/pato#increased_in_magnitude_relative_to

--- a/src/envo/imports/pato_terms.txt
+++ b/src/envo/imports/pato_terms.txt
@@ -262,5 +262,8 @@ http://purl.obolibrary.org/obo/PATO_0000440 # regular spatial pattern
 http://purl.obolibrary.org/obo/PATO_0001410 # striated
 http://purl.obolibrary.org/obo/PATO_0001453 # detached from
 http://purl.obolibrary.org/obo/PATO_0001935 # obtuse
+http://purl.obolibrary.org/obo/PATO_0000025 # composition
+http://purl.obolibrary.org/obo/PATO_0000140 # position
+http://purl.obolibrary.org/obo/PATO_0001997 # decreased amount
 http://purl.obolibrary.org/obo/pato#decreased_in_magnitude_relative_to
 http://purl.obolibrary.org/obo/pato#increased_in_magnitude_relative_to

--- a/src/envo/imports/pato_terms.txt
+++ b/src/envo/imports/pato_terms.txt
@@ -232,5 +232,34 @@ http://purl.obolibrary.org/obo/PATO_0001741 # radioactive
 http://purl.obolibrary.org/obo/PATO_0001456 # anaerobic
 http://purl.obolibrary.org/obo/PATO_0001455 # aerobic
 http://purl.obolibrary.org/obo/PATO_0015022 # combustible
+http://purl.obolibrary.org/obo/PATO_0001360 # filamentous
+http://purl.obolibrary.org/obo/PATO_0001608 # patchy
+http://purl.obolibrary.org/obo/PATO_0002215 # falciform
+http://purl.obolibrary.org/obo/PATO_0002386 # anvil
+http://purl.obolibrary.org/obo/PATO_0000404 # coiled
+http://purl.obolibrary.org/obo/PATO_0000405 # curled
+http://purl.obolibrary.org/obo/PATO_0002165 # drooping
+http://purl.obolibrary.org/obo/PATO_0040008 # fringed
+http://purl.obolibrary.org/obo/PATO_0002311 # fimbriated
+http://purl.obolibrary.org/obo/PATO_0002521 # funnel-shaped
+http://purl.obolibrary.org/obo/PATO_0001960 # interdigitated
+http://purl.obolibrary.org/obo/PATO_0015030 # plume-shaped
+http://purl.obolibrary.org/obo/PATO_0005005 # radiating
+http://purl.obolibrary.org/obo/PATO_0001367 # lobate
+http://purl.obolibrary.org/obo/PATO_0002441 # ornamented
+http://purl.obolibrary.org/obo/PATO_0002433 # sculpted surface
+http://purl.obolibrary.org/obo/PATO_0002335 # tholiform
+http://purl.obolibrary.org/obo/PATO_0002121 # trabecular
+http://purl.obolibrary.org/obo/PATO_0000634 # unilateral
+http://purl.obolibrary.org/obo/PATO_0010001 # disconnected
+http://purl.obolibrary.org/obo/PATO_0000642 # fused with
+http://purl.obolibrary.org/obo/PATO_0002103 # infiltrative
+http://purl.obolibrary.org/obo/PATO_0001846 # tangled
+http://purl.obolibrary.org/obo/PATO_0000701 # smooth
+http://purl.obolibrary.org/obo/PATO_0002255 # grooved
+http://purl.obolibrary.org/obo/PATO_0000406 # curved
+http://purl.obolibrary.org/obo/PATO_0000440 # regular spatial pattern
+http://purl.obolibrary.org/obo/PATO_0001410 # striated
+http://purl.obolibrary.org/obo/PATO_0001453 # detached from
 http://purl.obolibrary.org/obo/pato#decreased_in_magnitude_relative_to
 http://purl.obolibrary.org/obo/pato#increased_in_magnitude_relative_to


### PR DESCRIPTION
EDIT: I've realised, the additions I've made for #1002, are now part of this pull request, too. I'll cancel this one and instead proceed with #1002 to avoid confusion.

-----

In this pull request (linked to #999, and relevant to #998 and #1002 ☁️ ), I've added the terms low, middle, and high atmospheric level to ENVO. 

The definitions given by the [WMO cloud atlas](https://cloudatlas.wmo.int/en/useful-concepts.html#levels) (height ranges of the levels) were added as a comment.

I've left the `definition` blank because I have not yet found a definition source that clearly defines why the ranges of these atmospheric levels are what they are. I've made a note of that and the need to add human readable definitions as an `editor note`.

While adding the terms, I've noticed that the axiomatisation of [troposphere](http://purl.obolibrary.org/obo/ENVO_01000540) goes as such 
```
adjacent to some planetary surface and adjacent to some troposphere and part of some atmosphere
```
I've changed it to say `[...] and adjacent to some stratosphere [...]` (which I think is more appropriate).

Please let me know if you would like any revisions. Thank you 🙂 