### PR TITLE
Adding additional strictness - exact/label checks

### DIFF
--- a/src/envo/Makefile
+++ b/src/envo/Makefile
@@ -511,7 +511,7 @@ all_robot_reports: reports/envo-edit-robot-report.tsv reports/envo-base-robot-re
 # we use a modified profile that allows missing labels, as we sometimes declare properties on
 # an auto-class from modules (e.g ENVO:09200020)
 reports/envo-edit-robot-report.tsv: $(PRE_SRC)
-	$(ROBOT) report -p reports/report_profile_edit.txt -l true -i $< --fail-on $(REPORT_FAIL_ON) --print 5 -o $@
+	$(ROBOT) report -p reports/report_profile_edit.txt -l true -i $< --fail-on ERROR --print 5 -o $@
 
 # default profile
 reports/envo-src-robot-report.tsv: $(SRC)

--- a/src/envo/reports/report_profile_edit.txt
+++ b/src/envo/reports/report_profile_edit.txt
@@ -3,8 +3,8 @@ ERROR	deprecated_boolean_datatype
 ERROR	deprecated_class_reference
 ERROR	deprecated_property_reference
 ERROR	duplicate_definition
-WARN	duplicate_exact_synonym
-WARN	duplicate_label_synonym
+ERROR	duplicate_exact_synonym
+ERROR	duplicate_label_synonym
 ERROR	duplicate_label
 WARN	duplicate_scoped_synonym
 WARN	equivalent_pair


### PR DESCRIPTION
We want to be flag any exact/label syn clashes as errors and block release﻿
