### PR TITLE
add functionality to replace CRLF in modules/*.csv with LF

### DIFF
--- a/src/envo/Makefile
+++ b/src/envo/Makefile
@@ -539,9 +539,8 @@ all_modules: all_modules_owl all_modules_obo
 all_modules_owl: $(ALL_MODS_OWL)
 all_modules_obo: $(patsubst %, modules/%.obo, $(MODS))
 
-modules/%.owl: modules/%.csv patterns/%.yaml curie_map.yaml .FORCE
-	# replace crlf with lf 
-	@perl -pe 's/\r\n/\n/' $< > $<.tmp && mv $<.tmp $<
+modules/%.owl: modules/%.csv patterns/%.yaml curie_map.yaml 
+	@perl -pe 's/\r\n/\n/' $< > $<.tmp && mv $<.tmp $< # replace crlf with lf
 	dosdp-tools --table-format=csv --template=./patterns/$*.yaml --outfile=modules/$*.tmp.owl --obo-prefixes=true generate --infile=modules/$*.csv
 	$(ROBOT) annotate --input modules/$*.tmp.owl -O http://purl.obolibrary.org/obo/envo/modules/$*.owl --output modules/$*.owl && rm modules/$*.tmp.owl
 

--- a/src/envo/Makefile
+++ b/src/envo/Makefile
@@ -539,7 +539,9 @@ all_modules: all_modules_owl all_modules_obo
 all_modules_owl: $(ALL_MODS_OWL)
 all_modules_obo: $(patsubst %, modules/%.obo, $(MODS))
 
-modules/%.owl: modules/%.csv patterns/%.yaml curie_map.yaml
+modules/%.owl: modules/%.csv patterns/%.yaml curie_map.yaml .FORCE
+	# replace crlf with lf 
+	@perl -pe 's/\r\n/\n/' $< > $<.tmp && mv $<.tmp $<
 	dosdp-tools --table-format=csv --template=./patterns/$*.yaml --outfile=modules/$*.tmp.owl --obo-prefixes=true generate --infile=modules/$*.csv
 	$(ROBOT) annotate --input modules/$*.tmp.owl -O http://purl.obolibrary.org/obo/envo/modules/$*.owl --output modules/$*.owl && rm modules/$*.tmp.owl
 


### PR DESCRIPTION
Add this to the make file to replace `CRLF` with `LF`:
```
modules/%.owl: modules/%.csv patterns/%.yaml curie_map.yaml .FORCE
        # replace crlf with lf
        @perl -pe 's/\r\n/\n/' $< > $<.tmp && mv $<.tmp $< <------- added
        dosdp-tools --table-format=csv --template=./patterns/$*.yaml --outfile=modules/$*.tmp.owl --obo-prefixes=true generate --infile=modules/$*.csv
        $(ROBOT) annotate --input modules/$*.tmp.owl -O http://purl.obolibrary.org/obo/envo/modules/$*.owl --output modules/$*.owl && rm modules/$*.tmp.owl
```
I tested by changing `LF` to `CRLF` for csvs in in modules/*.csv. Then I ran the Makefile and checked to verify that the 'CRLF` was replaced by `LF`.

Interesting aside:  
In order for the Make to run, I had change where `generate` occurred in the dosdp-tools call.  
I changed:
```
dosdp-tools --table-format=csv --template=./patterns/$*.yaml --outfile=modules/$*.tmp.owl --obo-prefixes=true generate --infile=modules/$*.csv
```
to
```
dosdp-tools generate --table-format=csv --template=./patterns/entity_attribute_location.yaml --outfile=modules/entity_attribute_location.tmp.owl --obo-prefixes=true --infile=modules/entity_attribute_location.csv
```
This change is **not** in this PR. I did not know if dosdp-tools as called here was referencing a previous version.
