### PR TITLE
Adding envoPlastics subset

### DIFF
--- a/src/envo/Makefile
+++ b/src/envo/Makefile
@@ -181,7 +181,7 @@ $(ONT)-full.owl: $(SRC) $(OTHER_SRC)
 
 
 SUBSETS = envo-basic EnvO-Lite-GSC envoEmpo envoAstro envoPolar envoEmpo envoOmics envoCesab environmental_hazards \
-   biome-hierarchy astronomical-body-part-hierarchy material-hierarchy process-hierarchy
+   biome-hierarchy astronomical-body-part-hierarchy material-hierarchy process-hierarchy envoPlastics
 
 SUBSET_ROOTS = $(patsubst %, subsets/%, $(SUBSETS))
 SUBSET_FILES = $(foreach n,$(SUBSET_ROOTS), $(foreach f,$(FORMATS_INCL_TSV), $(n).$(f)))


### PR DESCRIPTION
For our projects the UN Environment Working Group for SDG 14, I've created a subset for Plastics `envoPlastics` following the guidance on the corresponding [wiki page](https://github.com/EnvironmentOntology/envo/wiki/Making-a-new-subset), and @pbuttigieg's guidance [here](https://github.com/EnvironmentOntology/envo/issues/1085#issuecomment-816633363).

Please let me know if revisions are necessary.