### PR TITLE
Jagadish NMDC terms, without any makefile. #1089

### DIFF
--- a/src/envo/Makefile
+++ b/src/envo/Makefile
@@ -541,7 +541,7 @@ all_modules_obo: $(patsubst %, modules/%.obo, $(MODS))
 
 modules/%.owl: modules/%.csv patterns/%.yaml curie_map.yaml 
 	@perl -pe 's/\r\n/\n/' $< > $<.tmp && mv $<.tmp $< # replace crlf with lf
-	dosdp-tools --table-format=csv --template=./patterns/$*.yaml --outfile=modules/$*.tmp.owl --obo-prefixes=true generate --infile=modules/$*.csv
+	dosdp-tools generate --table-format=csv --template=./patterns/$*.yaml --outfile=modules/$*.tmp.owl --obo-prefixes=true --infile=modules/$*.csv
 	$(ROBOT) annotate --input modules/$*.tmp.owl -O http://purl.obolibrary.org/obo/envo/modules/$*.owl --output modules/$*.owl && rm modules/$*.tmp.owl
 
 modules/%.obo: modules/%.owl


### PR DESCRIPTION
Compiled from [Google Sheets robot template](https://docs.google.com/spreadsheets/d/1OQOtSlSjuw4OKre9YNE25-x9XnSNYaSPvbx_UjNZoBA/edit#gid=170789656)

See editor's notes for potential future improvements. I have used uppercase to indicate tasks that have been completed, like "ADDED 'composed primarily of' RO:0002473 mineral material 'ENVO:01000256'" on ENVO:03600011 'mineral horizon'

ontology ID | label
-- | --
ID | AL rdfs:label@en
ENVO:03600000 | cleanroom
ENVO:03600001 | contaminated sediment
ENVO:03600002 | cooling water
ENVO:03600003 | drinking water pipeline
ENVO:03600004 | drinking water treatment plant
ENVO:03600005 | electrical switch
ENVO:03600006 | food waste
ENVO:03600007 | formation fluid
ENVO:03600008 | intensive care unit
ENVO:03600009 | interstitial water
ENVO:03600010 | membrane bioreactor
ENVO:03600011 | mineral horizon
ENVO:03600012 | oil pipeline
ENVO:03600013 | oil sands
ENVO:03600014 | pipeline network
ENVO:03600015 | polluted river
ENVO:03600016 | saprolite
ENVO:03600017 | slurry
ENVO:03600018 | soil organic layer
ENVO:03600019 | sugarcane vinasse
ENVO:03600020 | tailings dam
ENVO:03600021 | tailings pond
ENVO:03600022 | vinasse

