### PR TITLE
Make sure DL profile check works

### DIFF
--- a/src/envo/Makefile
+++ b/src/envo/Makefile
@@ -64,13 +64,11 @@ test_python:
 
 # TODO: add this back to tests
 validate-dl-profile: $(PRE_SRC)
-# validates the DL profile for envo-edit merged with RO
-# note: The file is not part of the repo. It is there for you to check.
-# Use the command  "grep non-simple" to find non-simple violations
-	$(ROBOT) merge \
-        --input $< \
-        validate-profile --profile DL
-
+	# validates the DL profile for envo-edit merged with RO
+	# note: The file is not part of the repo. It is there for you to check.
+	#	Use the command  "grep non-simple" to find non-simple violations
+	$(ROBOT) merge -i $< convert -f ofn -o $(TMPDIR)/validate.ofn
+	$(ROBOT) validate-profile --profile DL -i $(TMPDIR)/validate.ofn
 
 ## -- main targets --
 ##


### PR DESCRIPTION
- ignoring missing declaration warnings
- @wdduncan you were right, the problem was not with the edit file, it was with the PRE release file. I think with regards to your conversion issue, as crazy as it sounds, you may have to first convert to some other format like RDFXML and then convert back to OFN so the serialiser adds the declaration. Not sure though. In any case, this is one way this check works!