### PR TITLE
Implement `ontobot-change-agent` as a GitHub action workflow

### DIFF
--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -44,7 +44,7 @@ jobs:
           echo "branch-name=kgcl_automation_"${{ steps.gh-script-issue.outputs.result }} >> $GITHUB_ENV
       
       - name: Get jar & create alias command.
-        run: wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-standalone-0.1.0.jar -O kgcl-robot.jar
+        run: wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-standalone-0.2.0.jar -O kgcl-robot.jar
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -44,7 +44,7 @@ jobs:
           echo "branch-name=kgcl_automation_"${{ steps.gh-script-issue.outputs.result }} >> $GITHUB_ENV
       
       - name: Get jar & create alias command.
-        run: wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.1.0/kgcl-robot-standalone-0.1.0.jar -O kgcl-robot.jar
+        run: wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-standalone-0.1.0.jar -O kgcl-robot.jar
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -1,0 +1,77 @@
+name: Create new pull request
+
+on:
+  workflow_dispatch:
+  issues:
+    types: [ opened, edited ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    container: obolibrary/odkfull:v1.4.1
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+        os: [ ubuntu-latest ]
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v3
+
+      - name: Return issue number
+        id: gh-script-issue
+        uses: actions/github-script@v6
+        with:
+          # github-token: ${{ secrets.GH_TOKEN }}
+          script: |
+            const issue_number = context.issue.number
+            const repo = context.repo.owner+"/"+context.repo.repo
+            return issue_number
+      
+      - name: Return repository name
+        id: gh-script-repo
+        uses: actions/github-script@v6
+        with:
+          # github-token: ${{ secrets.GH_TOKEN }}
+          script: |
+            const repo = context.repo.owner+"/"+context.repo.repo
+            return repo
+
+      - name: Set branch name
+        id: vars
+        run: |
+          echo "resource=src/envo/envo-edit.owl" >> $GITHUB_ENV
+          echo "branch-name=kgcl_automation_"${{ steps.gh-script-issue.outputs.result }} >> $GITHUB_ENV
+      
+      - name: Get jar & create alias command.
+        run: wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.1.0/kgcl-robot-standalone-0.1.0.jar -O kgcl-robot.jar
+      
+      - name: Install dependencies
+        run: |
+          pip install ontobot-change-agent
+
+      - name: Run ochange
+        id: ochange
+        run: |
+          ochange process-issue ${{ env.resource }} \
+          -r ${{ steps.gh-script-repo.outputs.result }} \
+          -n ${{ steps.gh-script-issue.outputs.result }} \
+          -g ${{ secrets.GH_TOKEN }} \
+          -j kgcl-robot.jar
+
+      - name: Clean-up
+        run: rm -f kgcl-robot.jar
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        if: ${{ env.PR_TITLE}}
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          branch-suffix: short-commit-hash
+          labels: Automated
+          author: ${{ env.ISSUE_CREATOR }} <${{ env.ISSUE_CREATOR }}@users.noreply.github.com>
+          committer: ${{ env.ISSUE_CREATOR }} <${{ env.ISSUE_CREATOR }}@users.noreply.github.com>
+          body: ${{ env.PR_BODY }}
+          title: ${{ env.PR_TITLE }}
+          base: ${{ github.head_ref }}
+          branch: ${{ env.branch-name }}


### PR DESCRIPTION
Each time an issue is created, the `ontobot.yml` workflow runs to see if there is a need for an intervention. If the issue has the phrase - "Hey ontobot, apply:" followed by bullets of KGCL commands. In response to such an issue, [`ontobot-change-agent` ](https://github.com/hrshdhgd/ontobot-change-agent) is invoked to make appropriate change suggetstions to the `src/ontology/envo-edit.owl` file and create a pull request linking itself to the original issue that triggered it.

An example: 
- Issue: https://github.com/hrshdhgd/envo/issues/1
- Associated PR: https://github.com/hrshdhgd/envo/pull/10

- [x] **Note**: For this workflow to work, a GitHub token needs to be aded to the repository's `Settings` tab.
UPDATE: I've taken care of the above.

Attention: @cmungall 