### PR TITLE
Addressing #865 with desert biome example

### DIFF
--- a/src/envo/patterns/biome.yaml
+++ b/src/envo/patterns/biome.yaml
@@ -1,0 +1,36 @@
+pattern_name: biome patterns
+pattern_iri: http://purl.obolibrary.org/obo/envo/biome
+
+description: >-
+
+  A biome is an ecosystem that participates in some climactic ecological succession, ie it is resilient to perturbations
+  It should be possible to infer that class with "biome" in its label should be classified as a 'biome'.
+  Does this pattern generate biomes from all ecosystems, or does it check the patterns of classes that are already present?
+
+classes: 
+  biome: ENVO:00000428
+  ecosystem: ENVO:01001110
+  climactic ecological succession: ENVO:01001827
+
+relations:
+  participates in: RO:0000056
+
+vars:
+  participant: "'ecosystem'"
+
+# TODO: this will create names that include 'ecosystem' in the label, like 'desert ecosystem biome'
+#  we would prefer to REPLACE 'ecosystem' with 'biome'
+name:
+  text: "%s biome"
+  vars:
+    - participant
+
+def:
+  text: "An %s that is undergoing climactic ecological succession."
+  vars:
+    - participant
+
+equivalentTo: 
+  text: "%s and ('participates in' some 'climactic ecological succession')"
+  vars:
+    - participant

--- a/src/envo/patterns/ecosystem.yaml
+++ b/src/envo/patterns/ecosystem.yaml
@@ -1,0 +1,34 @@
+pattern_name: ecosystem patterns
+pattern_iri: http://purl.obolibrary.org/obo/envo/ecosystem
+
+description: >-
+
+  An ecosystem is any environmental system which has both biotic and abiotic parts. 
+  Ecosystems are typically defined by some entity that "determines" them. For example, 
+  a desert ecosystem is determined by the presence of a desert - if the desert wasn't there, 
+  it wouldn't be a desert ecosystem.
+
+classes:
+  ecosystem: ENVO:01001110
+  material entity: BFO:0000040
+
+relations:
+  determined by: RO:0002507
+
+vars:
+  determinant: "'material entity'"
+
+name:
+  text: "%s ecosystem"
+  vars:
+    - determinant
+
+def:
+  text: "An ecosystem in which the composition, structure, and function of resident ecological assemblages are primarily determined by a(n) %s."
+  vars:
+    - determinant
+
+equivalentTo: 
+  text: "ecosystem and ('determined by' some %s)"
+  vars:
+    - determinant


### PR DESCRIPTION
This PR is picking up and will hopefully close multiple issues related to the biome hierarchy and semantics.

The approach used is to leverage a process class for ecological succession in climax communities. We acknowledge that the notion of climax communities is being refined in modern ecology, and have attempted to reflect this in the definitions and terminology (i.e. we do not content that any ecological community can ever reached an idealised climax state, but we do not that successional process can slow or maintain a community). 

We'll start with a desert example, get the pattern stable, and then propagate changes across terms (xref #1321)