### PR TITLE
Update `ontobot.yml` workflow to use `kgcl-java` as a plugin to robot that already exists in ODK.

### DIFF
--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -6,7 +6,30 @@ on:
     types: [ opened, edited ]
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      phraseExists: ${{ steps.check-body.outputs.result }}
+    steps:
+      - name: Check if issue body contains 'Hey ontobot'
+        id: check-body
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const issue = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            if (!issue.data.body) {
+              console.log('Issue body is empty or null');
+              return false;
+            }
+            return issue.data.body.includes('Hey ontobot');
+
   build:
+    needs: check
+    if: needs.check.outputs.phraseExists == 'true'
     runs-on: ${{ matrix.os }}
     container: obolibrary/odkfull:v1.4.3
     strategy:

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -43,7 +43,7 @@ jobs:
           echo "resource=src/envo/envo-edit.owl" >> $GITHUB_ENV
           echo "branch-name=kgcl_automation_"${{ steps.gh-script-issue.outputs.result }} >> $GITHUB_ENV
       
-      - name: Get jar & create alias command.
+      - name: Get jar & enable plugin.
         run: |
           mkdir -p robot-plugins
           wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-plugin-0.2.0.jar -O robot-plugins/kgcl.jar

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -51,7 +51,7 @@ jobs:
       
       - name: Install dependencies
         run: |
-          pip install git+https://github.com/hrshdhgd/ontobot-change-agent.git
+          pip install ontobot-change-agent
 
       - name: Run ochange
         id: ochange

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    container: obolibrary/odkfull:v1.4.1
+    container: obolibrary/odkfull:latest
     strategy:
       matrix:
         python-version: ["3.9"]
@@ -44,7 +44,9 @@ jobs:
           echo "branch-name=kgcl_automation_"${{ steps.gh-script-issue.outputs.result }} >> $GITHUB_ENV
       
       - name: Get jar & create alias command.
-        run: wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-plugin-0.2.0.jar -O kgcl.jar
+        run: |
+          mkdir -p ~/.robot/plugins
+          wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-plugin-0.2.0.jar -O ~/.robot/plugins/kgcl.jar
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           mkdir -p ~/.robot/plugins
           wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-plugin-0.2.0.jar -O ~/.robot/plugins/kgcl.jar
-          "ROBOT_PLUGINS_DIRECTORY='~/.robot/plugins'" >> "$GITHUB_ENV"
+          "ROBOT_PLUGINS_DIRECTORY='/github/home/.robot/plugins/'" >> "$GITHUB_ENV"
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -45,9 +45,9 @@ jobs:
       
       - name: Get jar & create alias command.
         run: |
-          mkdir -p ~/.robot/plugins
-          wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-plugin-0.2.0.jar -O ~/.robot/plugins/kgcl.jar
-          "ROBOT_PLUGINS_DIRECTORY=/github/home/.robot/plugins/" >> "$GITHUB_ENV"
+          mkdir -p robot-plugins
+          wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-plugin-0.2.0.jar -O robot-plugins/kgcl.jar
+          "ROBOT_PLUGINS_DIRECTORY=robot-plugins/" >> "$GITHUB_ENV"
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           mkdir -p robot-plugins
           wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-plugin-0.2.0.jar -O robot-plugins/kgcl.jar
-          "ROBOT_PLUGINS_DIRECTORY=${{pwd}}/robot-plugins/" >> "$GITHUB_ENV"
+          echo "ROBOT_PLUGINS_DIRECTORY=$(pwd)/robot-plugins/" >> "$GITHUB_ENV"
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
           mkdir -p ~/.robot/plugins
           wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-plugin-0.2.0.jar -O ~/.robot/plugins/kgcl.jar
+          "ROBOT_PLUGINS_DIRECTORY=r~/.robot/plugins" >> "$GITHUB_ENV"
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -44,13 +44,11 @@ jobs:
           echo "branch-name=kgcl_automation_"${{ steps.gh-script-issue.outputs.result }} >> $GITHUB_ENV
       
       - name: Get jar & create alias command.
-        run: |
-          mkdir -p ~/.robot/plugin
-          wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-plugin-0.2.0.jar -O ~/.robot/plugin/kgcl.jar
+        run: wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-plugin-0.2.0.jar -O kgcl.jar
       
       - name: Install dependencies
         run: |
-          pip install ontobot-change-agent==0.4.7rc1
+          pip install git+https://github.com/hrshdhgd/ontobot-change-agent.git
 
       - name: Run ochange
         id: ochange

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    container: obolibrary/odkfull:latest
+    container: obolibrary/odkfull:1.4.3
     strategy:
       matrix:
         python-version: ["3.9"]

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -44,11 +44,13 @@ jobs:
           echo "branch-name=kgcl_automation_"${{ steps.gh-script-issue.outputs.result }} >> $GITHUB_ENV
       
       - name: Get jar & create alias command.
-        run: wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-standalone-0.2.0.jar -O kgcl-robot.jar
+        run: |
+          mkdir -p ~/.robot/plugin
+          wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-plugin-0.2.0.jar -O ~/.robot/plugin/kgcl.jar
       
       - name: Install dependencies
         run: |
-          pip install ontobot-change-agent
+          pip install ontobot-change-agent==0.4.7rc1
 
       - name: Run ochange
         id: ochange
@@ -56,11 +58,7 @@ jobs:
           ochange process-issue ${{ env.resource }} \
           -r ${{ steps.gh-script-repo.outputs.result }} \
           -n ${{ steps.gh-script-issue.outputs.result }} \
-          -g ${{ secrets.GH_TOKEN }} \
-          -j kgcl-robot.jar
-
-      - name: Clean-up
-        run: rm -f kgcl-robot.jar
+          -g ${{ secrets.GH_TOKEN }}
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           mkdir -p ~/.robot/plugins
           wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-plugin-0.2.0.jar -O ~/.robot/plugins/kgcl.jar
-          "ROBOT_PLUGINS_DIRECTORY=r~/.robot/plugins" >> "$GITHUB_ENV"
+          "ROBOT_PLUGINS_DIRECTORY=~/.robot/plugins" >> "$GITHUB_ENV"
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -25,7 +25,7 @@ jobs:
               console.log('Issue body is empty or null');
               return false;
             }
-            return issue.data.body.includes('Hey ontobot');
+            return issue.data.body.toLowerCase().includes('hey ontobot');
 
   build:
     needs: check

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    container: obolibrary/odkfull:1.4.3
+    container: obolibrary/odkfull:v1.4.3
     strategy:
       matrix:
         python-version: ["3.9"]

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -61,6 +61,9 @@ jobs:
           -n ${{ steps.gh-script-issue.outputs.result }} \
           -g ${{ secrets.GH_TOKEN }}
 
+      - name: Clean-up
+        run: rm -rf robot-plugins
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         if: ${{ env.PR_TITLE}}

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           mkdir -p ~/.robot/plugins
           wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-plugin-0.2.0.jar -O ~/.robot/plugins/kgcl.jar
-          "ROBOT_PLUGINS_DIRECTORY='/github/home/.robot/plugins/'" >> "$GITHUB_ENV"
+          "ROBOT_PLUGINS_DIRECTORY=/github/home/.robot/plugins/" >> "$GITHUB_ENV"
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           mkdir -p ~/.robot/plugins
           wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-plugin-0.2.0.jar -O ~/.robot/plugins/kgcl.jar
-          "ROBOT_PLUGINS_DIRECTORY=~/.robot/plugins" >> "$GITHUB_ENV"
+          "ROBOT_PLUGINS_DIRECTORY='~/.robot/plugins'" >> "$GITHUB_ENV"
       
       - name: Install dependencies
         run: |

--- a/.github/workflows/ontobot.yml
+++ b/.github/workflows/ontobot.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           mkdir -p robot-plugins
           wget https://github.com/gouttegd/kgcl-java/releases/download/kgcl-0.2.0/kgcl-robot-plugin-0.2.0.jar -O robot-plugins/kgcl.jar
-          "ROBOT_PLUGINS_DIRECTORY=robot-plugins/" >> "$GITHUB_ENV"
+          "ROBOT_PLUGINS_DIRECTORY=${{pwd}}/robot-plugins/" >> "$GITHUB_ENV"
       
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Previously we were downloading a standalone JAR file for `kgcl-java` which included robot. This required downloading robot which was redundant and not very efficient. ROBOT plugin usage is enabled as a feature since the latest release (v1.9.5) and this is packaged within the latest version of ODK (v1.4.3). 

This PR basically leverages those features and we only download the `kgcl-java` plugin JAR and use the robot that is available via ODK to use `kgcl-java` as. plugin and perform the same way as before.


**UPDATE**: Added a preliminary check for the phrase `Hey ontobot` in the issue body before running the whole workflow.