### PR TITLE
Add materialize step to ENVO full version

### DIFF
--- a/src/envo/Makefile
+++ b/src/envo/Makefile
@@ -176,6 +176,7 @@ $(ONT)-full.owl: $(SRC) $(OTHER_SRC)
 	$(ROBOT) merge --input $< \
 		reason --reasoner ELK --equivalent-classes-allowed asserted-only --exclude-tautologies structural \
 		relax \
+		materialize -term BFO:0000050 \
 		reduce -r ELK \
 		annotate --ontology-iri $(ONTBASE)/$@ --version-iri $(ONTBASE)/releases/$(TODAY)/$@  -a owl:versionInfo $(TODAY)\
                 --output $@.tmp.owl && mv $@.tmp.owl $@


### PR DESCRIPTION
- [ ] review @balhoff

See #1614 

I also noted in the makefile that the base file is still the totally antequated version without reasoning.. Does this not bother you @balhoff - this must lead to a lot of problems with missing classification?