### PR TITLE
Introduce SOTA base file generation process

### DIFF
--- a/src/envo/Makefile
+++ b/src/envo/Makefile
@@ -163,12 +163,23 @@ $(ONTOLOGYTERMS): $(SRC) $(OTHER_SRC)
 	$(ROBOT) query --use-graphs true -f csv -i $< --query ../sparql/envo_terms.sparql $@
 
 
-# base: OTHER sources of interest, such as definitions owl
-$(ONT)-base.owl: $(SRC) $(OTHER_SRC)
-	$(ROBOT) remove --input $< --select imports --trim false \
-		merge $(patsubst %, -i %, $(OTHER_SRC)) \
-		annotate --annotation http://purl.org/dc/elements/1.1/type http://purl.obolibrary.org/obo/IAO_8000001 \
-		--ontology-iri $(ONTBASE)/$@ --version-iri $(ONTBASE)/releases/$(TODAY)/$@ -a owl:versionInfo $(TODAY) \
+EDIT_PREPROCESSED =         $(TMPDIR)/$(ONT)-preprocess.owl
+
+$(EDIT_PREPROCESSED): $(SRC)
+	$(ROBOT) convert --input $< --format ofn --output $@
+
+# ROBOT pipeline that merges imports, including components.
+ROBOT_RELEASE_IMPORT_MODE=$(ROBOT) merge --input $< 
+
+# base: A version of the ontology that does not include any externally imported axioms.
+$(ONT)-base.owl: $(EDIT_PREPROCESSED) $(OTHER_SRC) $(IMPORT_FILES)
+	$(ROBOT_RELEASE_IMPORT_MODE) \
+	reason --reasoner ELK --equivalent-classes-allowed asserted-only --exclude-tautologies structural --annotate-inferred-axioms False \
+	relax \
+	reduce -r ELK \
+	remove --base-iri http://purl.obolibrary.org/obo/ENVO_ --base-iri http://purl.obolibrary.org/obo/envo# --axioms external --preserve-structure false --trim false \
+	annotate --link-annotation http://purl.org/dc/elements/1.1/type http://purl.obolibrary.org/obo/IAO_8000001 \
+		--ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) \
 		--output $@.tmp.owl && mv $@.tmp.owl $@
 
 # Full: The full artefacts with imports merged, reasoned


### PR DESCRIPTION
Remaining problem: this kills two axiom injections:

```
SubClassOf(<http://purl.obolibrary.org/obo/FOODON_00002403> <http://purl.obolibrary.org/obo/ENVO_00010483>)
SubClassOf(<http://purl.obolibrary.org/obo/OBI_0000968> <http://purl.obolibrary.org/obo/ENVO_00003074>)
```