### PR TITLE
wetland ecosystem: re-parent under terrestrial ecosystem (#1659)

### DIFF
--- a/src/envo/envo-edit.owl
+++ b/src/envo/envo-edit.owl
@@ -30220,7 +30220,7 @@ AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#has
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "USGS:SDTS") <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/ENVO_01001209> "morass")
 AnnotationAssertion(Annotation(<http://www.geneontology.org/formats/oboInOwl#hasDbXref> "USGS:SDTS") <http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym> <http://purl.obolibrary.org/obo/ENVO_01001209> "muskeg")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/ENVO_01001209> "wetland ecosystem"@en)
-SubClassOf(<http://purl.obolibrary.org/obo/ENVO_01001209> <http://purl.obolibrary.org/obo/ENVO_01001110>)
+SubClassOf(<http://purl.obolibrary.org/obo/ENVO_01001209> <http://purl.obolibrary.org/obo/ENVO_01001790>)
 SubClassOf(<http://purl.obolibrary.org/obo/ENVO_01001209> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/ENVO_01000635> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002473> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/ENVO_00001998> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000086> <http://purl.obolibrary.org/obo/PATO_0001823>))))))
 
 # Class: <http://purl.obolibrary.org/obo/ENVO_01001210> (defence against flooding)


### PR DESCRIPTION
Re-parents wetland ecosystem (ENVO:01001209) from ecosystem to terrestrial ecosystem, so the hierarchy matches its definition ("A terrestrial ecosystem which is inundated or saturated...") and its subtree (peatland, fen, marsh, etc.) sits under terrestrial ecosystem / astronomical body part like the other ecosystem classes. Resolves #1659.

Reasoning stays consistent and travis_test passes; no new dosdp-conforms violations (the pre-existing biome ones are #1601). Whether wetland should sit under terrestrial ecosystem is your call.
