### PR TITLE
Add 'wetland biome' (ENVO:03605010) via the biome pattern (#1658)

### DIFF
--- a/src/envo/envo-edit.owl
+++ b/src/envo/envo-edit.owl
@@ -47436,4 +47436,15 @@ AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IAO_0000412> "imp
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IAO_0000424> "expand expression to")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/RO_0001900> "An assertion that holds between an OWL Object Property and a temporal interpretation that elucidates how OWL Class Axioms that use this property are to be interpreted in a temporal context.")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/RO_0001900> "temporal interpretation")
+
+# Class: <http://purl.obolibrary.org/obo/ENVO_03605010> (wetland biome)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/ENVO_03605010> "A wetland ecosystem that is undergoing climactic ecological succession.")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#created_by> <http://purl.obolibrary.org/obo/ENVO_03605010> "ORCID:0000-0001-9076-6066")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.obolibrary.org/obo/ENVO_03605010> "2026-06-18T03:39:02Z")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/ENVO_03605010> "wetland biome")
+Declaration(Class(<http://purl.obolibrary.org/obo/ENVO_03605010>))
+EquivalentClasses(<http://purl.obolibrary.org/obo/ENVO_03605010> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/ENVO_01001209> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000056> <http://purl.obolibrary.org/obo/ENVO_01001827>)))
+SubClassOf(<http://purl.obolibrary.org/obo/ENVO_03605010> <http://purl.obolibrary.org/obo/ENVO_01001209>)
+
 )


### PR DESCRIPTION
Adds wetland biome (ENVO:03605010) via the biome pattern: wetland ecosystem and ('participates in' some 'climactic ecological succession'), subClassOf wetland ecosystem. Resolves #1658. Stacked on #1661, merge that first.

It gives the Microflora Danica bogs/mires/fens habitats (~530 samples in PRJNA1071982) an env_broad_scale value other than flooded grassland biome. travis_test passes. Like all biomes, the conformsTo tag depends on regenerating patterns/matches (#1601).
