### PR TITLE
Add wetland biome (ENVO:03605010) via biome pattern (#1658)

### DIFF
--- a/src/envo/envo-edit.owl
+++ b/src/envo/envo-edit.owl
@@ -47436,4 +47436,15 @@ AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IAO_0000412> "imp
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/IAO_0000424> "expand expression to")
 AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/RO_0001900> "An assertion that holds between an OWL Object Property and a temporal interpretation that elucidates how OWL Class Axioms that use this property are to be interpreted in a temporal context.")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/RO_0001900> "temporal interpretation")
+
+# Class: <http://purl.obolibrary.org/obo/ENVO_03605010> (wetland biome)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/ENVO_03605010> "A wetland ecosystem that is undergoing climactic ecological succession.")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#created_by> <http://purl.obolibrary.org/obo/ENVO_03605010> "ORCID:0000-0001-9076-6066")
+AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.obolibrary.org/obo/ENVO_03605010> "2026-06-18T03:39:02Z")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/ENVO_03605010> "wetland biome")
+Declaration(Class(<http://purl.obolibrary.org/obo/ENVO_03605010>))
+EquivalentClasses(<http://purl.obolibrary.org/obo/ENVO_03605010> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/ENVO_01001209> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000056> <http://purl.obolibrary.org/obo/ENVO_01001827>)))
+SubClassOf(<http://purl.obolibrary.org/obo/ENVO_03605010> <http://purl.obolibrary.org/obo/ENVO_01001209>)
+
 )


### PR DESCRIPTION
Adds `wetland biome` (ENVO:03605010), a DOSDP-compliant biome on the biome design pattern: equivalent to `wetland ecosystem and ('participates in' some 'climactic ecological succession')`, `SubClassOf wetland ecosystem`. Resolves #1658. Stacked on #1663, merge that first.

- Provides a MIxS `env_broad_scale` value for peat-forming wetlands.
- Use case: the Microflora Danica "Bogs, mires and fens" habitats (Natura2000/EUNIS 7000), ~530 samples; coastal salt marshes use the existing `marine salt marsh biome`.
- `travis_test` passes; classifies under `biome` / `terrestrial ecosystem` / `astronomical body part`. Conformance tagging follows the existing `patterns/matches` regeneration (#1601).
