### PR TITLE
Add wetland biome (ENVO:03605010) via biome pattern (#1666)

### DIFF
--- a/src/envo/envo-edit.owl
+++ b/src/envo/envo-edit.owl
@@ -3981,6 +3981,7 @@ Declaration(Class(<http://purl.obolibrary.org/obo/ENVO_03605006>))
 Declaration(Class(<http://purl.obolibrary.org/obo/ENVO_03605007>))
 Declaration(Class(<http://purl.obolibrary.org/obo/ENVO_03605008>))
 Declaration(Class(<http://purl.obolibrary.org/obo/ENVO_03605009>))
+Declaration(Class(<http://purl.obolibrary.org/obo/ENVO_03605010>))
 Declaration(Class(<http://purl.obolibrary.org/obo/ENVO_04000000>))
 Declaration(Class(<http://purl.obolibrary.org/obo/ENVO_04000001>))
 Declaration(Class(<http://purl.obolibrary.org/obo/ENVO_04000002>))
@@ -44899,6 +44900,15 @@ AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibra
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/ENVO_03605009> "freshwater stream ecosystem"@en)
 EquivalentClasses(<http://purl.obolibrary.org/obo/ENVO_03605009> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/ENVO_01001789> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002507> <http://purl.obolibrary.org/obo/ENVO_03605007>)))
 SubClassOf(<http://purl.obolibrary.org/obo/ENVO_03605009> <http://purl.obolibrary.org/obo/ENVO_01001789>)
+
+# Class: <http://purl.obolibrary.org/obo/ENVO_03605010> (wetland biome)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/ENVO_03605010> "A wetland ecosystem that is undergoing climactic ecological succession.")
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/creator> <http://purl.obolibrary.org/obo/ENVO_03605010> <https://orcid.org/0000-0001-9076-6066>)
+AnnotationAssertion(<http://purl.org/dc/elements/1.1/date> <http://purl.obolibrary.org/obo/ENVO_03605010> "2026-06-18T04:45:15Z"^^xsd:dateTime)
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/ENVO_03605010> "wetland biome"@en)
+EquivalentClasses(<http://purl.obolibrary.org/obo/ENVO_03605010> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/ENVO_01001209> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0000056> <http://purl.obolibrary.org/obo/ENVO_01001827>)))
+SubClassOf(<http://purl.obolibrary.org/obo/ENVO_03605010> <http://purl.obolibrary.org/obo/ENVO_01001209>)
 
 # Class: <http://purl.obolibrary.org/obo/ENVO_04000000> (adfreezing)
 


### PR DESCRIPTION
Adds `wetland biome` (ENVO:03605010), a DOSDP-compliant biome on the biome design pattern: equivalent to `wetland ecosystem and ('participates in' some 'climactic ecological succession')`, `SubClassOf wetland ecosystem`. Resolves #1666. Stacked on the re-parent PR, merge that first.

- Provides a MIxS `env_broad_scale` value for peat-forming wetlands.
- Use case: the Microflora Danica "Bogs, mires and fens" habitats (Natura2000/EUNIS 7000), ~530 samples; coastal salt marshes use the existing `marine salt marsh biome`.
- `travis_test` passes